### PR TITLE
ログインするAPIを追加

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,13 @@
+class SessionsController < ApplicationController
+  def create
+    @session = Session.new(login_params)
+    render_error @session, 401 unless @session.save
+    @session
+  end
+
+  private
+
+  def login_params
+    params.permit(:email, :password)
+  end
+end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,35 @@
+class Session
+  include ActiveModel::Model
+
+  def initialize(params)
+    @params = params
+  end
+
+  def save
+    if authenticate
+      true
+    else
+      errors[:base] << I18n.t('errors.messages.sessions.invalid_parameters')
+      false
+    end
+  end
+
+  def token
+    return nil unless authenticate
+    @token ||= user.add_access_token
+  end
+
+  private
+
+  def authenticate
+    user && user.active? && user.authenticate(@params[:password])
+  end
+
+  def user
+    @user ||= find_user
+  end
+
+  def find_user
+    EmailUser.find_by(email: @params[:email])
+  end
+end

--- a/app/views/sessions/create.json.jbuilder
+++ b/app/views/sessions/create.json.jbuilder
@@ -1,0 +1,1 @@
+json.access_token @session.token.token

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resource :session, only: %i(create)
+
   namespace :email_user do
     resources :registrations, only: %i(create) do
       get :regist

--- a/spec/requests/sign_in_spec.rb
+++ b/spec/requests/sign_in_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe 'POST /session?email=email&password=password', autodoc: true do
+  let!(:user) do
+    create(:email_user, :registered,
+           email: 'login@example.com', password: 'password')
+  end
+  let!(:email) { 'login@example.com' }
+  let!(:password) { 'password' }
+  let!(:params) { { email: email, password: password } }
+
+  context 'ユーザーの本登録が完了している場合' do
+    it '200が返ってくること' do
+      post '/session', params
+
+      expect(response.status).to eq 200
+    end
+  end
+
+  context 'ユーザーの本登録が完了していない場合' do
+    before do
+      user.status = :inactive
+      user.save
+    end
+
+    it '401とエラーメッセージが返ってくること' do
+      post '/session', params
+
+      expect(response.status).to eq 401
+      json = {
+        error_messages: ['メールアドレスまたはパスワードが正しくありません']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+
+  context 'ユーザーが見つからない場合' do
+    let(:email) { 'dummy@example.com' }
+
+    it '401とエラーメッセージが返ってくること' do
+      post '/session', params
+
+      expect(response.status).to eq 401
+      json = {
+        error_messages: ['メールアドレスまたはパスワードが正しくありません']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+
+  context 'パスワードが不正な場合' do
+    let(:password) { 'dummy_password' }
+
+    it '401とエラーメッセージが返ってくること' do
+      post '/session', params
+
+      expect(response.status).to eq 401
+      json = {
+        error_messages: ['メールアドレスまたはパスワードが正しくありません']
+      }
+      expect(response.body).to be_json_as(json)
+    end
+  end
+end

--- a/spec/requests/sign_up_spec.rb
+++ b/spec/requests/sign_up_spec.rb
@@ -85,7 +85,6 @@ describe 'PATCH /email_user/registrations/:id?token=token', autodoc: true do
     end
 
     it 'ログインできるようになっていること' do
-      pending
       get "/email_user/registrations/#{@user_id}/regist", token: @token
       expect(response.status).to eq 302
 

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,0 +1,8 @@
+module RequestSpecHelper
+  def login_headers(user)
+    valid_token = user.find_token_by_name(:access)
+    valid_token ||= user.add_access_token
+    { Authorization: ActionController::HttpAuthentication::Token\
+      .encode_credentials(valid_token.token) }
+  end
+end


### PR DESCRIPTION
アカウント登録済みのメールアドレスとパスワードでログインできるようにしました。

ログインに成功した場合、セッションのtokenが返ってきます。
そのtokenを使って、ajaxで処理をします。

ajaxで処理する場合は、ヘッダのAuthorizationにtokenを設定することで、ログインしている処理を行います。

`{ Authorization: ActionController::HttpAuthentication::Token.encode_credentials(valid_token.token) }`
